### PR TITLE
socket.io と socket.io-client を v4.5.1 にアップデート

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "passport": "0.6.0",
     "passport-github2": "0.1.12",
     "pug": "3.0.2",
-    "socket.io": "4.4.1",
-    "socket.io-client": "4.4.1"
+    "socket.io": "4.5.1",
+    "socket.io-client": "4.5.1"
   },
   "devDependencies": {
     "@babel/core": "7.17.5",


### PR DESCRIPTION
socket.io と socket.io-client を v4.5.1 にアップデートしました。
（ https://github.com/nnn-training/change-repo-contents-all を使って作成しました）